### PR TITLE
Fix for the definition of miget_dimension_sizes.

### DIFF
--- a/pyminc/volumes/libpyminc2.py
+++ b/pyminc/volumes/libpyminc2.py
@@ -82,6 +82,7 @@ dimensions = c_void_p * 5
 voxel = c_double
 location = c_ulonglong * 5
 int_sizes = c_ulonglong * 5
+uint_sizes = c_uint * 5
 long_sizes = c_ulong * 5
 misize_t_sizes = c_ulonglong * 5
 double_sizes = c_double * 5
@@ -96,7 +97,7 @@ libminc.miopen_volume.argtypes = [c_char_p, c_int, POINTER(mihandle)]
 libminc.miget_real_value.argtypes = [mihandle, location, c_int, POINTER(voxel)]
 libminc.miget_volume_dimensions.argtypes = [mihandle, c_int, c_int, c_int,
 					    c_int, dimensions]
-libminc.miget_dimension_sizes.argtypes = [dimensions, misize_t, int_sizes]
+libminc.miget_dimension_sizes.argtypes = [dimensions, misize_t, uint_sizes]
 libminc.miget_dimension_name.argtypes = [c_void_p, POINTER(c_char_p)]
 libminc.miget_dimension_separations.argtypes = [dimensions, c_int, misize_t, 
 											    double_sizes]

--- a/pyminc/volumes/volumes.py
+++ b/pyminc/volumes/volumes.py
@@ -19,7 +19,7 @@ class mincVolume(object):
         self.dims = dimensions()     # holds the actual pointers to dimensions
         self.ndims = 0               # number of dimensions in this volume
         self.ndims_misize_t = 0      # same number, but in different format
-        self.sizes = int_sizes()     # holds dimension sizes info
+        self.sizes = uint_sizes()    # holds dimension sizes info
         self.dataLoadable = False    # we know enough about the file on disk to load data
         self.dataLoaded = False      # data sits inside the .data attribute
         self.dtype = dtype           # default datatype for array representation
@@ -396,6 +396,7 @@ class mincVolume(object):
                 testMincReturn(r)
         self.dims = apply(dimensions, tmpdims[0:self.ndims])
         self.separations = steps
+        for i in range(self.ndims): self.sizes[i] = sizes[i]
 
     def closeVolume(self):
         """close volume and release all pointer memory"""

--- a/scripts/pyminc_test2.py
+++ b/scripts/pyminc_test2.py
@@ -25,7 +25,7 @@ def minc_test(input, method, output):
    
    # get volume dimensions and their sizes
    d = dimensions(0,0,0)
-   s = int_sizes(0,0,0)
+   s = uint_sizes(0,0,0)
    libminc.miget_volume_dimensions(test, MI_DIMCLASS_SPATIAL, MI_DIMATTR_ALL,
 				MI_DIMORDER_FILE, 3, d)
    libminc.miget_dimension_sizes(d, 3, s)


### PR DESCRIPTION
The full definition from MINC-2.2.00 is:

```
extern int miget_dimension_sizes(const midimhandle_t dimensions[], int array_length,
             unsigned int sizes[]);
```

The definition in libpyminc2.py has int_sizes (C's unsigned long long)
for the last parameter, but it should be uint_sizes.

Test script:

```
from pyminc.volumes.factory import *
import numpy as np
import os

tmp = '/tmp/test.mnc'

try:
    os.remove(tmp)
except OSError:
    pass

shape = (10, 20)

vol = volumeFromDescription(tmp, ['yspace', 'xspace'], shape, [-5, -5], [0.2, 0.2])
vol.data = np.random.random(shape)
print vol.data.shape # should say (10, 20)
vol.writeFile()
vol.closeVolume()
```

Result:

```
$ python test_creation.py
Traceback (most recent call last):
  File "test_creation.py", line 15, in <module>
    vol.data = np.random.random(shape)
  File "/usr/local/lib/python2.7/dist-packages/pyminc/volumes/volumes.py", line 63, in setdata
    raise IncorrectDimsException
pyminc.volumes.volumes.IncorrectDimsException
```

After the fix:

```
$ python test_creation.py
(10, 20)
```

I tested scripts/pyminc_test2.py and it seemed to run successfully:

```
$ ./pyminc_test2.py /tmp/test.mnc numpy /tmp/test_out.mnc
4
Opening volume took 0.01000 seconds
Voxel: 0.000000
sizes: 110 217 181
0
Getting hyperslab took 0.15000 seconds
55
0
(4320470,)
(110, 217, 181)
0
computing ten neighbourhood averages using numpy method
Iterations 0 took 0.260 seconds
Iterations 1 took 0.230 seconds
Iterations 2 took 0.220 seconds
Iterations 3 took 0.230 seconds
Iterations 4 took 0.230 seconds
Iterations 5 took 0.220 seconds
Iterations 6 took 0.230 seconds
Iterations 7 took 0.230 seconds
Iterations 8 took 0.220 seconds
Iterations 9 took 0.230 seconds
done averaging. Took a total of 2.300 seconds, averaging 0.230 seconds
before volume
after volume
max and min 87 0
(110, 217, 181)
Creating new volume took 0.36000 seconds
before setting hyperslab
0
0.0
0 255 0 63.2519589304
int32 uint8
[[[0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]
  ...,
  [0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]]

 [[0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]
  ...,
  [0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]]

 [[0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]
  ...,
  [0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]]

 ...,
 [[0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]
  ...,
  [0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]]

 [[0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]
  ...,
  [0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]]

 [[0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]
  ...,
  [0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]
  [0 0 0 ..., 0 0 0]]]
Setting hyperslab took 0.09000 seconds

$ mincstats /tmp/test.mnc
File:              /tmp/test.mnc
Mask file:         (null)
Total voxels:      4320470
# voxels:          4320470
% of total:        100
Volume (mm3):      4320470
Min:               0
Max:               102.5024482
Sum:               102940629.4
Sum^2:             5570867979
Mean:              23.82625718
Variance:          721.7221255
Stddev:            26.86488648
CoM_voxel(z,y,x):  42.81716948 105.8562036 90.67176645
CoM_real(x,y,z):   0.6717664491 -20.14379639 30.81716948

Histogram:         (null)
Total voxels:      4320470
# voxels:          4320470
% of total:        100
Median:            0.03855289613
Majority:          0.02562561259
BiModalT:          28.26505089
PctT [  0%]:       0.02562561259
Entropy :          5.90236189

$ mincstats /tmp/test_out.mnc
File:              /tmp/test_out.mnc
Mask file:         (null)
Total voxels:      4320470
# voxels:          4320470
% of total:        100
Volume (mm3):      4320470
Min:               0
Max:               87
Sum:               93236088.69
Sum^2:             4408692362
Mean:              21.58008011
Variance:          554.7198926
Stddev:            23.55249228
CoM_voxel(z,y,x):  42.56045625 105.8436785 90.68415457
CoM_real(x,y,z):   0.6841545723 -20.15632149 30.56045625

Histogram:         (null)
Total voxels:      4320470
# voxels:          4320470
% of total:        100
Median:            8.808750357
Majority:          0.02174999937
BiModalT:          24.90374947
PctT [  0%]:       0.02174999937
Entropy :          3.946002744
```

Note: all testing was done on Debian Wheezy 64bit; I got segfaults
on Debian Wheezy 32bit with the latest commit and also my patches.
Is pyminc compatible with 32bit systems?
