### PR TITLE
Fix inverted login label code

### DIFF
--- a/pyminc/volumes/volumes.py
+++ b/pyminc/volumes/volumes.py
@@ -439,8 +439,8 @@ class mincVolume(object):
         if self.labels:
             if max > vmax or min < vmin:
                 raise ValueError("label volume found where max or min label exceeds max or min of volume type")
-            vmax = max
-            vmin = min
+            max = vmax
+            min = vmin
         r = libminc.miset_volume_range(self.volPointer, max, min)
         testMincReturn(r)
         r = libminc.miset_volume_valid_range(self.volPointer, vmax, vmin)


### PR DESCRIPTION
Fixing inverted logic in label code which accidentally allows label files to have scaling applied to them.

Tested with:
```py
from pyminc.volumes.factory import *
infile = volumeFromFile("/home/gdevenyi/localtemp/brain1_labels.mnc", dtype='ubyte', labels=True)
outfile = volumeFromInstance(infile, "/tmp/test.mnc", dtype='ubyte', volumeType='ubyte', labels=True)

outfile.data = infile.data

outfile.writeFile()
outfile.closeVolume()
```
Loads in a label file and writes it out.

Before(note voxel value vs real value in bottom left)
![image](https://user-images.githubusercontent.com/3001850/63644927-e1c0af80-c6c1-11e9-8a37-dc9dd2dd3d69.png)

After(voxel and real value now correspond)
![image](https://user-images.githubusercontent.com/3001850/63644931-01f06e80-c6c2-11e9-87fc-2a5fd6a136dc.png)

